### PR TITLE
Update OWNERS file for Korean l10n work

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,22 +1,11 @@
 # Reviewers can /lgtm /approve but not sufficient for auto-merge without an
 # approver
 reviewers:
-- Rajakavitha1
-- stewart-yu
-- xiangpengzhao
-- zhangxiaoyu-zidif
+- ianychoi
 
 # Approvers have all the ability of reviewers but their /approve makes
 # auto-merge happen if a /lgtm exists, or vice versa, or they can do both
 # No need for approvers to also be listed as reviewers
 approvers:
-- bradamant3
-- bradtopol
-- chenopis
-- kbarnard10
-- mistyhacks
-- ryanmcginnis
-- steveperry-53
-- tengqm
-- zacharysarah
-- zparnold
+- ClaudiaJKang
+- gochist


### PR DESCRIPTION
According to the [election result at 2018-06-27](https://docs.google.com/document/d/1sPF1XYmayMnA4WuIr4TJLdpfF9oMoX4nYN-1ncu61ew/edit#heading=h.fo1u4ksczk39), add initial reviewers and an approver.