### PR TITLE
[Setup] page's header and sub header translate into Korean.

### DIFF
--- a/content/ko/docs/setup/_index.md
+++ b/content/ko/docs/setup/_index.md
@@ -1,6 +1,6 @@
 ---
 no_issue: true
-title: Setup
+title: 설치
 main_menu: true
 weight: 30
 ---

--- a/content/ko/docs/setup/building-from-source.md
+++ b/content/ko/docs/setup/building-from-source.md
@@ -1,12 +1,12 @@
 ---
-title: Building from Source
+title: 소스로부터 빌드
 ---
 
 You can either build a release from source or download a pre-built release.  If you do not plan on developing Kubernetes itself, we suggest using a pre-built version of the current release, which can be found in the [Release Notes](/docs/imported/release/notes/).
 
 The Kubernetes source code can be downloaded from the [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) repo.
 
-## Building from source
+## 소스로부터 빌드
 
 If you are simply building a release from source there is no need to set up a full golang environment as all building happens in a Docker container.
 

--- a/content/ko/docs/setup/cluster-large.md
+++ b/content/ko/docs/setup/cluster-large.md
@@ -1,8 +1,8 @@
 ---
-title: Building Large Clusters
+title: 대형 클러스터 구축
 ---
 
-## Support
+## 지원
 
 At {{< param "version" >}}, Kubernetes supports clusters with up to 5000 nodes. More specifically, we support configurations that meet *all* of the following criteria:
 
@@ -15,7 +15,7 @@ At {{< param "version" >}}, Kubernetes supports clusters with up to 5000 nodes. 
 
 {{< toc >}}
 
-## Setup
+## 설치
 
 A cluster is a set of nodes (physical or virtual machines) running Kubernetes agents, managed by a "master" (the cluster-level control plane).
 
@@ -25,7 +25,7 @@ Simply changing that value to something very large, however, may cause the setup
 
 When setting up a large Kubernetes cluster, the following issues must be considered.
 
-### Quota Issues
+### 쿼터 문제
 
 To avoid running into cloud provider quota issues, when creating a cluster with many nodes, consider:
 
@@ -41,7 +41,7 @@ To avoid running into cloud provider quota issues, when creating a cluster with 
     * Target pools
 * Gating the setup script so that it brings up new node VMs in smaller batches with waits in between, because some cloud providers rate limit the creation of VMs.
 
-### Etcd storage
+### Etcd 저장소
 
 To improve performance of large clusters, we store events in a separate dedicated etcd instance.
 
@@ -50,7 +50,7 @@ When creating a cluster, existing salt scripts:
 * start and configure additional etcd instance
 * configure api-server to use it for storing events
 
-### Size of master and master components
+### 마스터 크기와 마스터 구성 요소
 
 On GCE/Google Kubernetes Engine, and AWS, `kube-up` automatically configures the proper VM size for your master depending on the number of nodes
 in your cluster. On other providers, you will need to configure it manually. For reference, the sizes we use on GCE are
@@ -77,7 +77,7 @@ On Google Kubernetes Engine, the size of the master node adjusts automatically b
 On AWS, master node sizes are currently set at cluster startup time and do not change, even if you later scale your cluster up or down by manually removing or adding nodes or using a cluster autoscaler.
 {{< /note >}}
 
-### Addon Resources
+### 애드온 자원
 
 To prevent memory leaks or other resource issues in [cluster addons](https://releases.k8s.io/{{< param "githubbranch" >}}/cluster/addons) from consuming all the resources available on a node, Kubernetes sets resource limits on addon containers to limit the CPU and Memory resources they can consume (See PR [#10653](http://pr.k8s.io/10653/files) and [#10778](http://pr.k8s.io/10778/files)).
 
@@ -116,7 +116,7 @@ For directions on how to detect if addon containers are hitting resource limits,
 In the [future](http://issue.k8s.io/13048), we anticipate to set all cluster addon resource limits based on cluster size, and to dynamically adjust them if you grow or shrink your cluster.
 We welcome PRs that implement those features.
 
-### Allowing minor node failure at startup
+### 시작 시 사소한 노드 오류 허용
 
 For various reasons (see [#18969](https://github.com/kubernetes/kubernetes/issues/18969) for more details) running
 `kube-up.sh` with a very large `NUM_NODES` may fail due to a very small number of nodes not coming up properly.

--- a/content/ko/docs/setup/custom-cloud/_index.md
+++ b/content/ko/docs/setup/custom-cloud/_index.md
@@ -1,3 +1,3 @@
 ---
-title: Custom Cloud Solutions
+title: 사용자 지정 클라우드 솔루션
 ---

--- a/content/ko/docs/setup/on-premises-vm/_index.md
+++ b/content/ko/docs/setup/on-premises-vm/_index.md
@@ -1,3 +1,3 @@
 ---
-title: On-Premises VMs
+title: 온-프레미스 VM
 ---

--- a/content/ko/docs/setup/pick-right-solution.md
+++ b/content/ko/docs/setup/pick-right-solution.md
@@ -1,5 +1,5 @@
 ---
-title: Picking the Right Solution
+title: 알맞은 솔루션 선정
 content_template: templates/concept
 ---
 
@@ -25,7 +25,7 @@ a Kubernetes cluster from scratch.
 
 {{% capture body %}}
 
-## Local-machine Solutions
+## 로컬 머신 솔루션
 
 * [Minikube](/docs/setup/minikube/) is the recommended method for creating a local, single-node Kubernetes cluster for development and testing. Setup is completely automated and doesn't require a cloud provider account.
 
@@ -37,7 +37,7 @@ a Kubernetes cluster from scratch.
 
 * [IBM Cloud Private-CE (Community Edition) on Linux Containers](https://github.com/HSBawa/icp-ce-on-linux-containers) is a Terraform/Packer/BASH based Infrastructure as Code (IaC) scripts to create a seven node (1 Boot, 1 Master, 1 Management, 1 Proxy and 3 Workers) LXD cluster on  Linux Host.
 
-## Hosted Solutions
+## 호스트 된 솔루션
 
 * [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) offers managed Kubernetes clusters.
 
@@ -69,7 +69,7 @@ a Kubernetes cluster from scratch.
 
 * [Kublr](https://kublr.com) offers enterprise-grade secure, scalable, highly reliable Kubernetes clusters on AWS, Azure, GCP, and on-premise. It includes out-of-the-box backup and disaster recovery, multi-cluster centralized logging and monitoring, and built-in alerting.
 
-# Turnkey Cloud Solutions
+# 턴키 클라우드 솔루션
 
 These solutions allow you to create Kubernetes clusters on a range of Cloud IaaS providers with only a
 few commands. These solutions are actively developed and have active community support.
@@ -91,7 +91,7 @@ few commands. These solutions are actively developed and have active community s
 * [Kublr](https://kublr.com/)
 * [Alibaba Cloud](/docs/setup/turnkey/alibaba-cloud/)
 
-## On-Premises turnkey cloud solutions
+## 온-프레미스 턴키 클라우드 솔루션	
 These solutions allow you to create Kubernetes clusters on your internal, secure, cloud network with only a
 few commands.
 
@@ -103,7 +103,7 @@ few commands.
 * [Kontena Pharos](https://kontena.io/pharos/)
 * [Kublr](https://kublr.com/)
 
-## Custom Solutions
+## 사용자 지정 솔루션
 
 Kubernetes can run on a wide range of Cloud providers and bare-metal environments, and with many
 base operating systems.
@@ -116,13 +116,13 @@ cluster, try the [Getting Started from Scratch](/docs/setup/scratch/) guide.
 If you are interested in supporting Kubernetes on a new platform, see
 [Writing a Getting Started Guide](https://git.k8s.io/community/contributors/devel/writing-a-getting-started-guide.md).
 
-### Universal
+### 일반
 
 If you already have a way to configure hosting resources, use
 [kubeadm](/docs/setup/independent/create-cluster-kubeadm/) to easily bring up a cluster
 with a single command per machine.
 
-### Cloud
+### 클라우드
 
 These solutions are combinations of cloud providers and operating systems not covered by the above solutions.
 
@@ -133,7 +133,7 @@ These solutions are combinations of cloud providers and operating systems not co
 * [Gardener](https://gardener.cloud/)
 * [Kublr](https://kublr.com/)
 
-### On-Premises VMs
+### 온-프레미스 VM
 
 * [Vagrant](/docs/setup/custom-cloud/coreos/) (uses CoreOS and flannel)
 * [CloudStack](/docs/setup/on-premises-vm/cloudstack/) (uses Ansible, CoreOS and flannel)
@@ -143,14 +143,14 @@ These solutions are combinations of cloud providers and operating systems not co
 * [oVirt](/docs/setup/on-premises-vm/ovirt/)
 * [Fedora (Multi Node)](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/) (uses Fedora and flannel)
 
-### Bare Metal
+### 베어 메탈
 
 * [Fedora (Single Node)](/docs/getting-started-guides/fedora/fedora_manual_config/)
 * [Fedora (Multi Node)](/docs/getting-started-guides/fedora/flannel_multi_node_cluster/)
 * [Kubernetes on Ubuntu](/docs/getting-started-guides/ubuntu/)
 * [CoreOS](/docs/setup/custom-cloud/coreos/)
 
-### Integrations
+### 통합
 
 These solutions provide integration with third-party schedulers, resource managers, and/or lower level platforms.
 
@@ -158,7 +158,7 @@ These solutions provide integration with third-party schedulers, resource manage
   * Community Edition DCOS uses AWS
   * Enterprise Edition DCOS supports cloud hosting, on-premises VMs, and bare metal
 
-## Table of Solutions
+## 솔루션 표
 
 Below is a table of all of the solutions listed above.
 
@@ -209,7 +209,7 @@ Alibaba Cloud Container Service For Kubernetes | ROS        | CentOS | flannel/T
 **Note:** The above table is ordered by version test/used in nodes, followed by support level.
 {{< /note >}}
 
-### Definition of columns
+### 열 정의
 
 * **IaaS Provider** is the product or organization which provides the virtual or physical machines (nodes) that Kubernetes runs on.
 * **OS** is the base operating system of the nodes.

--- a/content/ko/docs/setup/turnkey/_index.md
+++ b/content/ko/docs/setup/turnkey/_index.md
@@ -1,3 +1,3 @@
 ---
-title: Turnkey Cloud Solutions
+title: 턴키 클라우드 솔루션
 ---


### PR DESCRIPTION
**#8 [Setup] Setup page's header and sub header translate into Korean.**
  - [X] [1. _index](https://kubernetes.io/docs/setup) | [파일](https://github.com/kubernetes/kubernetes-docs-ko/tree/dev-1.12/content/en/docs/setup/_index.md)
  - [X] [2. independent/_index](https://kubernetes.io/docs/setup/independent) | [파일](https://github.com/kubernetes/kubernetes-docs-ko/tree/dev-1.12/content/en/docs/setup/independent/_index.md)
  - [X] [3. turnkey/_index](https://kubernetes.io/docs/setup/turnkey) | [파일](https://github.com/kubernetes/kubernetes-docs-ko/tree/dev-1.12/content/en/docs/setup/turnkey/_index.md)
  - [X] [4. on-premises-vm/_index](https://kubernetes.io/docs/setup/on-premises-vm) | [파일](https://github.com/kubernetes/kubernetes-docs-ko/tree/dev-1.12/content/en/docs/setup/on-premises-vm/_index.md)
  - [X] [5. custom-cloud/_index](https://kubernetes.io/docs/setup/custom-cloud) | [파일](https://github.com/kubernetes/kubernetes-docs-ko/tree/dev-1.12/content/en/docs/setup/custom-cloud/_index.md)
  - [X] [6. Building Large Clusters](https://kubernetes.io/docs/setup/cluster-large) | [파일](https://github.com/kubernetes/kubernetes-docs-ko/tree/dev-1.12/content/en/docs/setup/cluster-large.md)
  - [X] [7. Building from Source](https://kubernetes.io/docs/setup/building-from-source) | [파일](https://github.com/kubernetes/kubernetes-docs-ko/tree/dev-1.12/content/en/docs/setup/building-from-source.md)
  - [X] [10. Picking the Right Solution](https://kubernetes.io/docs/setup/pick-right-solution) | [파일](https://github.com/kubernetes/kubernetes-docs-ko/tree/dev-1.12/content/en/docs/setup/pick-right-solution.md)